### PR TITLE
Allow / for options.dest

### DIFF
--- a/tasks/ftp_push.js
+++ b/tasks/ftp_push.js
@@ -109,7 +109,9 @@ module.exports = function (grunt) {
         index = 0,
         match;
 
-    destination = normalizeDir(destination);
+    if (destination !== "") {
+        destination = normalizeDir(destination);
+    }
     destinations.push(destination);
 
     // If there are other destinations specified in the dest obj of individual entries, add those here


### PR DESCRIPTION
Setting ``/`` as ``options.dest`` does not work as the destinations aren't allowed to start with ``/``.

This is needed for the following constructs (probably also for writing directly to the rootpath) as ``options.dest`` is checked for being not empty as requirement.

```javascript
    options: {
        ...
        dest: '/'
    },
    target1: {
        files: [{
            ...
            dest: 'foo/bar'
        }]
    },
    target2: {
        files: [{
            ...
            dest: 'bar/foo'
        }]
    }
```
