### PR TITLE
Relative files are written to wrong destination

### DIFF
--- a/tasks/ftp_push.js
+++ b/tasks/ftp_push.js
@@ -200,7 +200,6 @@ module.exports = function (grunt) {
       destPath = normalizeFilename(destPath);
       // file could have optional destination different from default, if so, add it here
       if (fileObject.dest) {
-        // Make sure relative destination ends in /
         destPath = rootDestination + fileObject.relDest;
       } else {
         destPath = rootDestination + destPath;

--- a/tasks/ftp_push.js
+++ b/tasks/ftp_push.js
@@ -118,7 +118,7 @@ module.exports = function (grunt) {
     fileObjects.forEach(function (fileItem) {
       if (fileItem.dest) {
         // Prepare the destination, then push into array for processing
-        preparedDestination = destination + normalizeDir(fileItem.dest);
+        preparedDestination = destination + fileItem.relDest;
         destinations.push(preparedDestination);
       } else {
         // Prepare the destination, then push into array for processing

--- a/tasks/ftp_push.js
+++ b/tasks/ftp_push.js
@@ -69,7 +69,8 @@ module.exports = function (grunt) {
         pathsForFiles.push({
           path: filepath,
           cwd: f.orig.cwd,
-          dest: f.orig.dest
+          dest: f.orig.dest,
+          relDest: f.dest
         });
       });
     });
@@ -200,8 +201,7 @@ module.exports = function (grunt) {
       // file could have optional destination different from default, if so, add it here
       if (fileObject.dest) {
         // Make sure relative destination ends in /
-        relativeDest = normalizeDir(fileObject.dest);
-        destPath = rootDestination + relativeDest + destPath;
+        destPath = rootDestination + fileObject.relDest;
       } else {
         destPath = rootDestination + destPath;
       }


### PR DESCRIPTION
IMHO relative files are written to wrong destination. Example:

Say we have the file ``sources/includes/foo.js`` and the following setting:

```javascript
    options: {
        dest: 'web'
    },
    target: {
        files: [{
            expand: true,
            cwd: 'sources/includes',
            src: '*.js',
            dest: 'inc'
        }]
    }
```

The file gets written to ``web/inc/sources/includes/foo.js`` at the moment what I think isn't the desired behavior. Otherwise why would we set ``files…cwd`` instead of just having the path in ``files…dest``.

IMHO the correct and expected result path would be ``web/inc/foo.js``

>resulting path = root path + relative dest path + cwd relative file path
