### PR TITLE
Hide credentials if necessary

### DIFF
--- a/tasks/ftp_push.js
+++ b/tasks/ftp_push.js
@@ -183,7 +183,12 @@ module.exports = function (grunt) {
       if (err) {
         grunt.fail.fatal(messages.authFailure(creds.username));
       } else {
-        grunt.log.ok(messages.authSuccess(creds.username));
+        if(gruntOptions.hideCredentialInLog){
+          grunt.log.ok(messages.authSuccess("<provided-username>"));
+        }
+        else{
+          grunt.log.ok(messages.authSuccess(creds.username));
+        }
       }
 
       // Push directories first

--- a/tasks/ftp_push.js
+++ b/tasks/ftp_push.js
@@ -183,8 +183,8 @@ module.exports = function (grunt) {
       if (err) {
         grunt.fail.fatal(messages.authFailure(creds.username));
       } else {
-        if(gruntOptions.hideCredentialInLog){
-          grunt.log.ok(messages.authSuccess("<provided-username>"));
+        if(options.hideCredentialInLog){
+          grunt.log.ok(messages.authSuccess('<provided-username>'));
         }
         else{
           grunt.log.ok(messages.authSuccess(creds.username));


### PR DESCRIPTION
For automatic ci systems like travis, it is often desired to hide credentials from public console log. For this, a proof of concept is showed here which hides log.

At present, only username is hid from console log and there is no mention of it into readme.md. But I think for proof of concept, it is ok...