### PR TITLE
Bumping grunt version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt": ">=0.4.0"
   },
   "dependencies": {
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.0",
     "jsftp": "^1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
At the moment we have the following dependency tree:
```
+-- grunt-ftp-push@1.1.1
| `-- grunt@0.4.5
|   `-- glob@3.1.21
|     `-- graceful-fs@1.2.3
```

That get's us problems with node releases >= v7.0:

> graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible.

Bumping grunt version requirement to v1 will (hopefully:-) solve that problem.
